### PR TITLE
Internal logging

### DIFF
--- a/ratatoskr/internal_logger.py
+++ b/ratatoskr/internal_logger.py
@@ -1,0 +1,11 @@
+# Set default logging handler to avoid "No handler found" warnings.
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+LOG = logging.getLogger(__name__)
+LOG.addHandler(NullHandler())

--- a/ratatoskr/operation_registry.py
+++ b/ratatoskr/operation_registry.py
@@ -1,6 +1,7 @@
 from protectron import protectron
 from schema import ValidOperationRegistryEventSchema
 from operation_wrappers.base_wrappers import OperationWrapper
+from internal_logger import LOG
 
 
 class InvalidOperationWrapperError(Exception):
@@ -14,15 +15,24 @@ class OperationRegistry:
     @classmethod
     def register_operation(cls, operation_wrapper):
         if not issubclass(operation_wrapper.__class__, OperationWrapper):
+
+            LOG.error('operation_wrapper [%s] is not a sublass of OperationWrapper',
+                      operation_wrapper.__class__)
+
             raise InvalidOperationWrapperError(
                 'operation_wrapper must be a subclass of OperationWrapper'
             )
+
         operation_name = operation_wrapper.get_wrapped_operation_name()
         OperationRegistry.registry[operation_name] = operation_wrapper
+
+        LOG.info('operation [%s] registered, operation_wrapper is [%s]',
+                 operation_name, operation_wrapper.__class__)
 
     @classmethod
     def deregister_operation(cls, operation_name):
         del OperationRegistry.registry[operation_name]
+        LOG.info('operation [%s] deregistered', operation_name)
 
     @classmethod
     def list_operations(cls):
@@ -38,4 +48,8 @@ class OperationRegistry:
         operation_name = event['operation']
         arguments = event['args']
         operation_wrapper = OperationRegistry.registry[operation_name]
+        LOG.debug('event [%s] is dispatched to operation [%s]',
+                  event, operation_name)
+        LOG.info('operation [%s] is called',
+                 operation_name)
         return operation_wrapper.call(**arguments)

--- a/ratatoskr/protectron.py
+++ b/ratatoskr/protectron.py
@@ -1,6 +1,8 @@
 import utils
 import schema
 
+from internal_logger import LOG
+
 
 def protectron(input_schema, output_schema=schema.EmptySchema()):
 
@@ -10,7 +12,15 @@ def protectron(input_schema, output_schema=schema.EmptySchema()):
             args_dict = utils.args_to_dict(func, args)
             arguments = utils.merge_args_with_kwargs(args_dict, kwargs)
             arguments = input_schema(arguments)
+
+            LOG.debug('input schema [%s] is applied to arguments [%s]',
+                      input_schema, arguments)
+
             output = output_schema(func(*args, **kwargs))
+
+            LOG.debug('output schema [%s] is applied to return value[%s]',
+                      output_schema, output)
+
             return output
 
         def peel_decorator():

--- a/ratatoskr/schema.py
+++ b/ratatoskr/schema.py
@@ -1,4 +1,5 @@
 from exceptions import Exception
+from internal_logger import LOG
 
 
 class SchemaValidationError(Exception):
@@ -20,7 +21,8 @@ class ValidOperationRegistryEventSchema:
         has_operation = 'operation' in payload
         has_args = 'args' in payload
         if not isinstance(event, dict) or not has_operation or not has_args:
-                raise SchemaValidationError(
-                    '"event" is not a dict or "operation" is not specified'
-                )
+            LOG.error('event schema validation failed, payload: %s', event)
+            raise SchemaValidationError(
+                '"event" is not a dict or "operation" is not specified'
+            )
         return event

--- a/tox.ini
+++ b/tox.ini
@@ -25,16 +25,18 @@ deps =
     {py27,py33,py34}: readme_renderer
     flake8
     pytest
+    pytest-capturelog
     voluptuous
     coverage
 commands =
     check-manifest --ignore tox.ini,requirements-dev.txt,*.pyc,.coverage,*.md,*.rst,.pre-commit-config.yaml
     # py26 doesn't have "setup.py check"
     # {py27,py33,py34}: python setup.py check -m -r -s
-    coverage run --source ratatoskr -m pytest -sv tests []
+    coverage run --source ratatoskr -m pytest --capture=sys -sv tests []
     coverage report
     flake8 ratatoskr
 
 [flake8]
 exclude = .tox,*.egg,build,data,__init__.py
 select = E,W,F
+max-line-length=120


### PR DESCRIPTION
fixes #7 
- internal_logger.LOG` now can be used as a library logger
- `pytest-capturelog` is added as a dependency to capture logs on failed
  testcases.
- `flake8` max-line-length parameter is added to avoid many lines long
  log descriptions
- logging added to different components
