### PR TITLE
operation_registry: exception on multiple ops

### DIFF
--- a/ratatoskr/operation_registry.py
+++ b/ratatoskr/operation_registry.py
@@ -8,6 +8,10 @@ class InvalidOperationWrapperError(Exception):
         pass
 
 
+class OperationAlreadyRegisteredError(Exception):
+        pass
+
+
 class OperationRegistry:
 
     registry = {}
@@ -24,6 +28,12 @@ class OperationRegistry:
             )
 
         operation_name = operation_wrapper.get_wrapped_operation_name()
+
+        if operation_name in OperationRegistry.registry:
+            LOG.error('operation [%s] is already registered in OperationRegistry',
+                      operation_name)
+            raise OperationAlreadyRegisteredError('%s' % operation_name)
+
         OperationRegistry.registry[operation_name] = operation_wrapper
 
         LOG.info('operation [%s] registered, operation_wrapper is [%s]',

--- a/tests/test_operation_registry.py
+++ b/tests/test_operation_registry.py
@@ -56,13 +56,32 @@ def test_operation_dispatch_with_args():
 def test_decorator_without_parantheses():
 
     @register_operation
-    def foo3(value):
+    def foo4(value):
         return value
 
     event = {
-        'operation': 'foo3',
+        'operation': 'foo4',
         'args': {'value': 69}
     }
 
     assert dispatch_event(event) == 69
 
+
+def test_decorator_multiple_registartions():
+
+    @register_operation
+    def foo5(value):
+        return value
+
+    with pytest.raises(ratatoskr.operation_registry.OperationAlreadyRegisteredError):
+
+        @register_operation
+        def foo4(value):
+            return value
+
+    event = {
+        'operation': 'foo4',
+        'args': {'value': 69}
+    }
+
+    assert dispatch_event(event) == 69


### PR DESCRIPTION
fixes #2
- `OperationAlreadyRegisteredError` introduced and thrown on registering
  two functions with the same name
- tests are modified according this new exception
- new testcase added to check

Signed-off-by: Gergő Nagy gnagy@aiss.hu
