### PR TITLE
Multiple decorators

### DIFF
--- a/ratatoskr/protectron.py
+++ b/ratatoskr/protectron.py
@@ -22,6 +22,7 @@ def protectron(input_schema, output_schema=schema.EmptySchema()):
     """
     def protectron_decorator(func):
 
+        @utils.wraps(func)
         def func_wrapper(*args, **kwargs):
             args_dict = utils.args_to_dict(func, args)
             arguments = utils.merge_args_with_kwargs(args_dict, kwargs)

--- a/tests/test_multiple_decorators.py
+++ b/tests/test_multiple_decorators.py
@@ -1,0 +1,42 @@
+import pytest
+
+from ratatoskr import protectron, register_operation, dispatch_event
+from voluptuous import Schema, Invalid
+
+
+def test_register_operation_wraps_protectron_matching_schema():
+
+    @register_operation
+    @protectron(Schema({'a': int}))
+    def mirror(a):
+        return a
+
+    event = {
+        'operation': 'mirror',
+        'args': {
+            'a': 42
+        }
+    }
+
+    assert dispatch_event(event) == 42
+
+
+def test_register_operation_wraps_protectron_unmatching_schema():
+
+    @register_operation
+    @protectron(Schema({'a': int}))
+    def mirror2(a):
+        return a
+
+    event = {
+        'operation': 'mirror2',
+        'args': {
+            'a': '42'
+        }
+    }
+
+    with pytest.raises(Invalid):
+        assert dispatch_event(event) == 42
+
+
+


### PR DESCRIPTION
It's now possible to use `register_operation` with `protectron`.
Protectron was returning the wrapper function that's name is registered
at the `OperationRegistry`.

Now it's possible to write the following code:

``` python

@register_operation
@protectron(is_int)
def foo(a):
    return a

```

The function decorated by `protectron` will be registered at the
`OperationRegistry`.
