### PR TITLE
protectron: default schema arguments handled

### DIFF
--- a/ratatoskr/protectron.py
+++ b/ratatoskr/protectron.py
@@ -31,7 +31,7 @@ def protectron(input_schema, output_schema=schema.EmptySchema()):
             LOG.debug('input schema [%s] is applied to arguments [%s]',
                       input_schema, arguments)
 
-            output = output_schema(func(*args, **kwargs))
+            output = output_schema(func(**arguments))
 
             LOG.debug('output schema [%s] is applied to return value[%s]',
                       output_schema, output)

--- a/tests/test_protectron.py
+++ b/tests/test_protectron.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ratatoskr import protectron
-from voluptuous import Schema, Invalid
+from voluptuous import Schema, Invalid, Required
 
 
 def test_protectron_empty_input_schema():
@@ -49,6 +49,15 @@ def test_protectron_kwargs_input_schema_unmatch():
 
     with pytest.raises(Invalid):
         foo(a='42', b=42)
+
+
+def test_protectron_kwargs_input_schema_with_default():
+
+    @protectron(Schema({Required('a', default=42): int, 'b': int}))
+    def foo(a, b):
+        return a
+
+    assert foo(b=42) == 42
 
 
 def test_protectron_empty_output_schema():


### PR DESCRIPTION
Now the following works: if the parameter with default value is not provided
at function call or event dispatch, the argument hash is extended by the
default value defined in the schema.

Example:

```
@protectron(
    Schema({
        Required('a', default=42): int,
        'b': int
    })
)
def foo(a, b):
    return a

assert foo(b=42) == 42
```

Signed-off-by: Kristof Havasi khavasi@aiss.hu
