### PR TITLE
Unregistered operation error exception

### DIFF
--- a/ratatoskr/operation_registry.py
+++ b/ratatoskr/operation_registry.py
@@ -12,6 +12,10 @@ class OperationAlreadyRegisteredError(Exception):
     pass
 
 
+class UnregisteredOperationError(Exception):
+    pass
+
+
 class OperationRegistry:
 
     registry = {}
@@ -87,7 +91,10 @@ class OperationRegistry:
         """
         operation_name = event['operation']
         arguments = event['args']
-        operation_wrapper = OperationRegistry.registry[operation_name]
+        try:
+            operation_wrapper = OperationRegistry.registry[operation_name]
+        except KeyError:
+            raise UnregisteredOperationError('operation [%s] is not registered' % operation_name)
         LOG.debug('event [%s] is dispatched to operation [%s]',
                   event, operation_name)
         LOG.info('operation [%s] is called',

--- a/tests/test_operation_registry.py
+++ b/tests/test_operation_registry.py
@@ -174,3 +174,14 @@ def test_operation_wrapper_call_is_not_implemented():
 
     with pytest.raises(NotImplementedError):
         assert dispatch_event(event) == 69
+
+
+def test_operation_registry_unregistered_operation():
+
+    event = {
+        'operation': 'dummy_unregistered_operation',
+        'args': {}
+    }
+
+    with pytest.raises(ratatoskr.operation_registry.UnregisteredOperationError):
+        dispatch_event(event)


### PR DESCRIPTION
`UnregisteredOperationError` is risen when an operation is called that
hasn't been registered. This exception hides the underlying
implementation of the operation registry.

It's possible that in the future new types of operation registries will
be implemented and it wouldn't be nice to use implementation specific
exceptions on lookup error.

fixes #20 
