### PR TITLE
exceptions: separate exceptions module introduced

### DIFF
--- a/ratatoskr/__init__.py
+++ b/ratatoskr/__init__.py
@@ -2,6 +2,8 @@ import utils
 import operation_registry
 import operation_wrappers.base_wrappers as base_wrappers
 import types
+import exceptions
+
 from protectron import protectron
 
 

--- a/ratatoskr/exceptions.py
+++ b/ratatoskr/exceptions.py
@@ -1,0 +1,28 @@
+class InvalidOperationWrapperError(Exception):
+    """
+        Raised when the custom user-provided operation wrapper does
+        not meet some requirements.
+    """
+    pass
+
+
+class OperationAlreadyRegisteredError(Exception):
+    """
+        Raised upon attempt to register an operation with a name that
+        is already present in the registry
+    """
+    pass
+
+
+class UnregisteredOperationError(Exception):
+    """
+        Raised on dispatching event with unregistered oparation field
+    """
+    pass
+
+
+class SchemaValidationError(Exception):
+    """
+        Raised on unmatching schema.
+    """
+    pass

--- a/ratatoskr/operation_registry.py
+++ b/ratatoskr/operation_registry.py
@@ -2,18 +2,11 @@ from protectron import protectron
 from schema import ValidOperationRegistryEventSchema
 from operation_wrappers.base_wrappers import OperationWrapper
 from internal_logger import LOG
-
-
-class InvalidOperationWrapperError(Exception):
-    pass
-
-
-class OperationAlreadyRegisteredError(Exception):
-    pass
-
-
-class UnregisteredOperationError(Exception):
-    pass
+from exceptions import (
+    InvalidOperationWrapperError,
+    OperationAlreadyRegisteredError,
+    UnregisteredOperationError
+)
 
 
 class OperationRegistry:

--- a/ratatoskr/schema.py
+++ b/ratatoskr/schema.py
@@ -1,11 +1,5 @@
 from internal_logger import LOG
-
-
-class SchemaValidationError(Exception):
-    """
-        Raised on unmatching schema.
-    """
-    pass
+from exceptions import SchemaValidationError
 
 
 class EmptySchema:


### PR DESCRIPTION
fixes #27 

The ratatoskr engine related exceptions have been assorted
to the 'exceptions' module which is available as ratatoskr.exceptions,
resulting in the usage example:

```
import ratatoskr

try:
  ...
  except ratatoskr.exceptions.SchemaValidationError as e:
  ...
```

Signed-off-by: hkrist kristof.havasi95@gmail.com
