### PR TITLE
pip: github prefers versions prefixed with `v`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     url=PROJECT_URL,
-    download_url=PROJECT_URL + '/tarball/' + VERSION,
+    download_url=PROJECT_URL + '/tarball/v' + VERSION,
     author='Gergo Nagy',
     author_email='grigori.grant@gmail.com',
     license='MIT',


### PR DESCRIPTION
For the tarball of a release is hosted by GitHub, the version in the
`VERSION` file must be prefixed with a `v`.

Signed-off-by: Gergő Nagy grigori.grant@gmail.com
