### PR TITLE
[READY] setup.py: pip req versioning fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_packages
 from os import path
-from pip.req import parse_requirements
+try: # for pip >= 10
+  from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+  from pip.req import parse_requirements
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Pip 10 is changed module structure with `pip.req`. Adding proper import
handling logic to the `setup.py` to install properly.

Signed-off-by: Gergő Nagy <contact@gergonagy.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngergo/ratatoskr/34)
<!-- Reviewable:end -->
