### PR TITLE
[READY] ratatoskr: deregister operation

### DIFF
--- a/ratatoskr/__init__.py
+++ b/ratatoskr/__init__.py
@@ -26,5 +26,11 @@ def register_operation(func, operation_wrapper=base_wrappers.LocalOperation):
     return wrapper
 
 
+def deregister_operation(operation_name):
+
+    operation_registry_cls = operation_registry.OperationRegistry
+    operation_registry_cls.deregister_operation(operation_name)
+
+
 def dispatch_event(event):
     return operation_registry.OperationRegistry.call(event)

--- a/ratatoskr/operation_registry.py
+++ b/ratatoskr/operation_registry.py
@@ -53,7 +53,8 @@ class OperationRegistry:
 
             After deregistering, the operation can't be called anymore.
         """
-        del OperationRegistry.registry[operation_name]
+        if operation_name in OperationRegistry.registry:
+            del OperationRegistry.registry[operation_name]
         LOG.info('operation [%s] deregistered', operation_name)
 
     @classmethod


### PR DESCRIPTION
Enable users to deregister their registered operations. In some cases it
can be useful especially when importing modules dynamically.

Signed-off-by: Gergő Nagy <contact@gergonagy.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ngergo/ratatoskr/37)
<!-- Reviewable:end -->
